### PR TITLE
Fix Unexpected token o in JSON at position 1 error

### DIFF
--- a/RealexPayments/HPP/view/frontend/web/js/model/realex-payment-service.js
+++ b/RealexPayments/HPP/view/frontend/web/js/model/realex-payment-service.js
@@ -42,7 +42,7 @@ define(
                 }
             },
             iframeResize: function(event) {
-                var data = JSON.parse(event);
+                var data = (typeof event !== 'object') ? JSON.parse(event) : event;
                 if (data.iframe && window.checkoutConfig.payment[quote.paymentMethod().method].iframeEnabled === '1') {
                     if (this.iframeHeight() != data.iframe.height && data.iframe.height != '0px') {
                         this.iframeHeight(data.iframe.height);


### PR DESCRIPTION
Fix for the JSON at position 1 error by checking the type and only parsing JSON if it is not an object.

Stacktrace of original error:
VM105091:1 Uncaught SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
    at Object.iframeResize (realex-payment-service.js:41)
    at hpp-method.js:33
    at dispatch (jquery.js:5232)
    at elemData.handle (jquery.js:4884)